### PR TITLE
[0.3.3] update bitcoin unicode from Ƀ to ₿

### DIFF
--- a/lib/cryptoformat.cjs.js
+++ b/lib/cryptoformat.cjs.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 // A map of supported currency codes to currency symbols.
 const supportedCurrencySymbols = {
-  BTC: "Ƀ",
+  BTC: "₿",
   ETH: "Ξ",
   USD: "$",
   CAD: "C$",
@@ -61,7 +61,11 @@ const symbolOverrides = {
 
 // Feature detection for Intl.NumberFormat
 function IntlNumberFormatSupported() {
-  return !!(typeof Intl == "object" && Intl && typeof Intl.NumberFormat == "function");
+  return !!(
+    typeof Intl == "object" &&
+    Intl &&
+    typeof Intl.NumberFormat == "function"
+  );
 }
 
 function isBTCETH(isoCode) {
@@ -81,8 +85,15 @@ function formatCurrencyOverride(formattedCurrency, locale = "en") {
 
     // Replace currency code with symbol if whitelisted.
     const overrideObj = symbolOverrides[code];
-    if (overrideObj && overrideObj.location.start && overrideObj.forLocales[locale]) {
-      return formattedCurrency.replace(currencyCodeFrontMatch[0], supportedCurrencySymbols[code]);
+    if (
+      overrideObj &&
+      overrideObj.location.start &&
+      overrideObj.forLocales[locale]
+    ) {
+      return formattedCurrency.replace(
+        currencyCodeFrontMatch[0],
+        supportedCurrencySymbols[code]
+      );
     } else {
       return formattedCurrency;
     }
@@ -95,7 +106,11 @@ function formatCurrencyOverride(formattedCurrency, locale = "en") {
 
     // Replace currency code with symbol if whitelisted.
     const overrideObj = symbolOverrides[code];
-    if (overrideObj && overrideObj.location.end && overrideObj.forLocales[locale]) {
+    if (
+      overrideObj &&
+      overrideObj.location.end &&
+      overrideObj.forLocales[locale]
+    ) {
       return formattedCurrency.replace(code, supportedCurrencySymbols[code]);
     } else {
       return formattedCurrency;
@@ -198,10 +213,14 @@ function initializeFormatters(isoCode, locale) {
   if (cachedFormatter == null) {
     formattersCache[cacheKey] = {};
     formattersCache[cacheKey].currencyFormatterNormal = currencyFormatterNormal;
-    formattersCache[cacheKey].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
+    formattersCache[
+      cacheKey
+    ].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
     formattersCache[cacheKey].currencyFormatterMedium = currencyFormatterMedium;
     formattersCache[cacheKey].currencyFormatterSmall = currencyFormatterSmall;
-    formattersCache[cacheKey].currencyFormatterVerySmall = currencyFormatterVerySmall;
+    formattersCache[
+      cacheKey
+    ].currencyFormatterVerySmall = currencyFormatterVerySmall;
   }
 }
 
@@ -232,19 +251,37 @@ function formatCurrency(amount, isoCode, locale = "en", raw = false) {
     }
 
     if (amount === 0.0) {
-      return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNormal.format(amount),
+        locale
+      );
     } else if (price >= LARGE_CRYPTO_THRESHOLD) {
       // Large crypto amount, show no decimal value
-      return formatCurrencyOverride(currencyFormatterNoDecimal.format(amount), locale);
-    } else if (price >= MEDIUM_CRYPTO_THRESHOLD && price < LARGE_CRYPTO_THRESHOLD) {
+      return formatCurrencyOverride(
+        currencyFormatterNoDecimal.format(amount),
+        locale
+      );
+    } else if (
+      price >= MEDIUM_CRYPTO_THRESHOLD &&
+      price < LARGE_CRYPTO_THRESHOLD
+    ) {
       // Medium crypto amount, show 3 fraction digits
-      return formatCurrencyOverride(currencyFormatterMedium.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterMedium.format(amount),
+        locale
+      );
     } else if (price >= 1.0 && price < MEDIUM_CRYPTO_THRESHOLD) {
       //  crypto amount, show 6 fraction digits
-      return formatCurrencyOverride(currencyFormatterSmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterSmall.format(amount),
+        locale
+      );
     } else {
       // Crypto amount < 1, show 8 fraction digits
-      return formatCurrencyOverride(currencyFormatterVerySmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterVerySmall.format(amount),
+        locale
+      );
     }
   } else {
     if (raw) {
@@ -258,20 +295,35 @@ function formatCurrency(amount, isoCode, locale = "en", raw = false) {
     }
 
     if (amount === 0.0) {
-      return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNormal.format(amount),
+        locale
+      );
     } else if (amount < 0.05) {
-      return formatCurrencyOverride(currencyFormatterVerySmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterVerySmall.format(amount),
+        locale
+      );
     } else if (amount < 1.0) {
-      return formatCurrencyOverride(currencyFormatterSmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterSmall.format(amount),
+        locale
+      );
     } else if (amount > 20000) {
-      return formatCurrencyOverride(currencyFormatterNoDecimal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNoDecimal.format(amount),
+        locale
+      );
     } else {
       // Let the formatter do what it seems best. In particular, we should not set any fraction amount for Japanese Yen
-      return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNormal.format(amount),
+        locale
+      );
     }
   }
 }
 
-exports.isCrypto = isCrypto;
 exports.clearCache = clearCache;
 exports.formatCurrency = formatCurrency;
+exports.isCrypto = isCrypto;

--- a/lib/cryptoformat.esm.js
+++ b/lib/cryptoformat.esm.js
@@ -1,6 +1,6 @@
 // A map of supported currency codes to currency symbols.
 const supportedCurrencySymbols = {
-  BTC: "Ƀ",
+  BTC: "₿",
   ETH: "Ξ",
   USD: "$",
   CAD: "C$",
@@ -57,7 +57,11 @@ const symbolOverrides = {
 
 // Feature detection for Intl.NumberFormat
 function IntlNumberFormatSupported() {
-  return !!(typeof Intl == "object" && Intl && typeof Intl.NumberFormat == "function");
+  return !!(
+    typeof Intl == "object" &&
+    Intl &&
+    typeof Intl.NumberFormat == "function"
+  );
 }
 
 function isBTCETH(isoCode) {
@@ -77,8 +81,15 @@ function formatCurrencyOverride(formattedCurrency, locale = "en") {
 
     // Replace currency code with symbol if whitelisted.
     const overrideObj = symbolOverrides[code];
-    if (overrideObj && overrideObj.location.start && overrideObj.forLocales[locale]) {
-      return formattedCurrency.replace(currencyCodeFrontMatch[0], supportedCurrencySymbols[code]);
+    if (
+      overrideObj &&
+      overrideObj.location.start &&
+      overrideObj.forLocales[locale]
+    ) {
+      return formattedCurrency.replace(
+        currencyCodeFrontMatch[0],
+        supportedCurrencySymbols[code]
+      );
     } else {
       return formattedCurrency;
     }
@@ -91,7 +102,11 @@ function formatCurrencyOverride(formattedCurrency, locale = "en") {
 
     // Replace currency code with symbol if whitelisted.
     const overrideObj = symbolOverrides[code];
-    if (overrideObj && overrideObj.location.end && overrideObj.forLocales[locale]) {
+    if (
+      overrideObj &&
+      overrideObj.location.end &&
+      overrideObj.forLocales[locale]
+    ) {
       return formattedCurrency.replace(code, supportedCurrencySymbols[code]);
     } else {
       return formattedCurrency;
@@ -194,10 +209,14 @@ function initializeFormatters(isoCode, locale) {
   if (cachedFormatter == null) {
     formattersCache[cacheKey] = {};
     formattersCache[cacheKey].currencyFormatterNormal = currencyFormatterNormal;
-    formattersCache[cacheKey].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
+    formattersCache[
+      cacheKey
+    ].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
     formattersCache[cacheKey].currencyFormatterMedium = currencyFormatterMedium;
     formattersCache[cacheKey].currencyFormatterSmall = currencyFormatterSmall;
-    formattersCache[cacheKey].currencyFormatterVerySmall = currencyFormatterVerySmall;
+    formattersCache[
+      cacheKey
+    ].currencyFormatterVerySmall = currencyFormatterVerySmall;
   }
 }
 
@@ -228,19 +247,37 @@ function formatCurrency(amount, isoCode, locale = "en", raw = false) {
     }
 
     if (amount === 0.0) {
-      return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNormal.format(amount),
+        locale
+      );
     } else if (price >= LARGE_CRYPTO_THRESHOLD) {
       // Large crypto amount, show no decimal value
-      return formatCurrencyOverride(currencyFormatterNoDecimal.format(amount), locale);
-    } else if (price >= MEDIUM_CRYPTO_THRESHOLD && price < LARGE_CRYPTO_THRESHOLD) {
+      return formatCurrencyOverride(
+        currencyFormatterNoDecimal.format(amount),
+        locale
+      );
+    } else if (
+      price >= MEDIUM_CRYPTO_THRESHOLD &&
+      price < LARGE_CRYPTO_THRESHOLD
+    ) {
       // Medium crypto amount, show 3 fraction digits
-      return formatCurrencyOverride(currencyFormatterMedium.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterMedium.format(amount),
+        locale
+      );
     } else if (price >= 1.0 && price < MEDIUM_CRYPTO_THRESHOLD) {
       //  crypto amount, show 6 fraction digits
-      return formatCurrencyOverride(currencyFormatterSmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterSmall.format(amount),
+        locale
+      );
     } else {
       // Crypto amount < 1, show 8 fraction digits
-      return formatCurrencyOverride(currencyFormatterVerySmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterVerySmall.format(amount),
+        locale
+      );
     }
   } else {
     if (raw) {
@@ -254,18 +291,33 @@ function formatCurrency(amount, isoCode, locale = "en", raw = false) {
     }
 
     if (amount === 0.0) {
-      return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNormal.format(amount),
+        locale
+      );
     } else if (amount < 0.05) {
-      return formatCurrencyOverride(currencyFormatterVerySmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterVerySmall.format(amount),
+        locale
+      );
     } else if (amount < 1.0) {
-      return formatCurrencyOverride(currencyFormatterSmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterSmall.format(amount),
+        locale
+      );
     } else if (amount > 20000) {
-      return formatCurrencyOverride(currencyFormatterNoDecimal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNoDecimal.format(amount),
+        locale
+      );
     } else {
       // Let the formatter do what it seems best. In particular, we should not set any fraction amount for Japanese Yen
-      return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNormal.format(amount),
+        locale
+      );
     }
   }
 }
 
-export { isCrypto, clearCache, formatCurrency };
+export { clearCache, formatCurrency, isCrypto };

--- a/lib/cryptoformat.umd.js
+++ b/lib/cryptoformat.umd.js
@@ -6,7 +6,7 @@
 
   // A map of supported currency codes to currency symbols.
   const supportedCurrencySymbols = {
-    BTC: "Ƀ",
+    BTC: "₿",
     ETH: "Ξ",
     USD: "$",
     CAD: "C$",
@@ -63,7 +63,11 @@
 
   // Feature detection for Intl.NumberFormat
   function IntlNumberFormatSupported() {
-    return !!(typeof Intl == "object" && Intl && typeof Intl.NumberFormat == "function");
+    return !!(
+      typeof Intl == "object" &&
+      Intl &&
+      typeof Intl.NumberFormat == "function"
+    );
   }
 
   function isBTCETH(isoCode) {
@@ -83,8 +87,15 @@
 
       // Replace currency code with symbol if whitelisted.
       const overrideObj = symbolOverrides[code];
-      if (overrideObj && overrideObj.location.start && overrideObj.forLocales[locale]) {
-        return formattedCurrency.replace(currencyCodeFrontMatch[0], supportedCurrencySymbols[code]);
+      if (
+        overrideObj &&
+        overrideObj.location.start &&
+        overrideObj.forLocales[locale]
+      ) {
+        return formattedCurrency.replace(
+          currencyCodeFrontMatch[0],
+          supportedCurrencySymbols[code]
+        );
       } else {
         return formattedCurrency;
       }
@@ -97,7 +108,11 @@
 
       // Replace currency code with symbol if whitelisted.
       const overrideObj = symbolOverrides[code];
-      if (overrideObj && overrideObj.location.end && overrideObj.forLocales[locale]) {
+      if (
+        overrideObj &&
+        overrideObj.location.end &&
+        overrideObj.forLocales[locale]
+      ) {
         return formattedCurrency.replace(code, supportedCurrencySymbols[code]);
       } else {
         return formattedCurrency;
@@ -200,10 +215,14 @@
     if (cachedFormatter == null) {
       formattersCache[cacheKey] = {};
       formattersCache[cacheKey].currencyFormatterNormal = currencyFormatterNormal;
-      formattersCache[cacheKey].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
+      formattersCache[
+        cacheKey
+      ].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
       formattersCache[cacheKey].currencyFormatterMedium = currencyFormatterMedium;
       formattersCache[cacheKey].currencyFormatterSmall = currencyFormatterSmall;
-      formattersCache[cacheKey].currencyFormatterVerySmall = currencyFormatterVerySmall;
+      formattersCache[
+        cacheKey
+      ].currencyFormatterVerySmall = currencyFormatterVerySmall;
     }
   }
 
@@ -234,19 +253,37 @@
       }
 
       if (amount === 0.0) {
-        return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+        return formatCurrencyOverride(
+          currencyFormatterNormal.format(amount),
+          locale
+        );
       } else if (price >= LARGE_CRYPTO_THRESHOLD) {
         // Large crypto amount, show no decimal value
-        return formatCurrencyOverride(currencyFormatterNoDecimal.format(amount), locale);
-      } else if (price >= MEDIUM_CRYPTO_THRESHOLD && price < LARGE_CRYPTO_THRESHOLD) {
+        return formatCurrencyOverride(
+          currencyFormatterNoDecimal.format(amount),
+          locale
+        );
+      } else if (
+        price >= MEDIUM_CRYPTO_THRESHOLD &&
+        price < LARGE_CRYPTO_THRESHOLD
+      ) {
         // Medium crypto amount, show 3 fraction digits
-        return formatCurrencyOverride(currencyFormatterMedium.format(amount), locale);
+        return formatCurrencyOverride(
+          currencyFormatterMedium.format(amount),
+          locale
+        );
       } else if (price >= 1.0 && price < MEDIUM_CRYPTO_THRESHOLD) {
         //  crypto amount, show 6 fraction digits
-        return formatCurrencyOverride(currencyFormatterSmall.format(amount), locale);
+        return formatCurrencyOverride(
+          currencyFormatterSmall.format(amount),
+          locale
+        );
       } else {
         // Crypto amount < 1, show 8 fraction digits
-        return formatCurrencyOverride(currencyFormatterVerySmall.format(amount), locale);
+        return formatCurrencyOverride(
+          currencyFormatterVerySmall.format(amount),
+          locale
+        );
       }
     } else {
       if (raw) {
@@ -260,23 +297,38 @@
       }
 
       if (amount === 0.0) {
-        return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+        return formatCurrencyOverride(
+          currencyFormatterNormal.format(amount),
+          locale
+        );
       } else if (amount < 0.05) {
-        return formatCurrencyOverride(currencyFormatterVerySmall.format(amount), locale);
+        return formatCurrencyOverride(
+          currencyFormatterVerySmall.format(amount),
+          locale
+        );
       } else if (amount < 1.0) {
-        return formatCurrencyOverride(currencyFormatterSmall.format(amount), locale);
+        return formatCurrencyOverride(
+          currencyFormatterSmall.format(amount),
+          locale
+        );
       } else if (amount > 20000) {
-        return formatCurrencyOverride(currencyFormatterNoDecimal.format(amount), locale);
+        return formatCurrencyOverride(
+          currencyFormatterNoDecimal.format(amount),
+          locale
+        );
       } else {
         // Let the formatter do what it seems best. In particular, we should not set any fraction amount for Japanese Yen
-        return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+        return formatCurrencyOverride(
+          currencyFormatterNormal.format(amount),
+          locale
+        );
       }
     }
   }
 
-  exports.isCrypto = isCrypto;
   exports.clearCache = clearCache;
   exports.formatCurrency = formatCurrency;
+  exports.isCrypto = isCrypto;
 
   Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@coingecko/cryptoformat",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coingecko/cryptoformat",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Javascript library to format and display cryptocurrencies and fiat",
   "main": "lib/cryptoformat.cjs.js",
   "module": "lib/cryptoformat.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // A map of supported currency codes to currency symbols.
 const supportedCurrencySymbols = {
-  BTC: "Ƀ",
+  BTC: "₿",
   ETH: "Ξ",
   USD: "$",
   CAD: "C$",
@@ -57,7 +57,11 @@ const symbolOverrides = {
 
 // Feature detection for Intl.NumberFormat
 function IntlNumberFormatSupported() {
-  return !!(typeof Intl == "object" && Intl && typeof Intl.NumberFormat == "function");
+  return !!(
+    typeof Intl == "object" &&
+    Intl &&
+    typeof Intl.NumberFormat == "function"
+  );
 }
 
 function isBTCETH(isoCode) {
@@ -77,8 +81,15 @@ function formatCurrencyOverride(formattedCurrency, locale = "en") {
 
     // Replace currency code with symbol if whitelisted.
     const overrideObj = symbolOverrides[code];
-    if (overrideObj && overrideObj.location.start && overrideObj.forLocales[locale]) {
-      return formattedCurrency.replace(currencyCodeFrontMatch[0], supportedCurrencySymbols[code]);
+    if (
+      overrideObj &&
+      overrideObj.location.start &&
+      overrideObj.forLocales[locale]
+    ) {
+      return formattedCurrency.replace(
+        currencyCodeFrontMatch[0],
+        supportedCurrencySymbols[code]
+      );
     } else {
       return formattedCurrency;
     }
@@ -91,7 +102,11 @@ function formatCurrencyOverride(formattedCurrency, locale = "en") {
 
     // Replace currency code with symbol if whitelisted.
     const overrideObj = symbolOverrides[code];
-    if (overrideObj && overrideObj.location.end && overrideObj.forLocales[locale]) {
+    if (
+      overrideObj &&
+      overrideObj.location.end &&
+      overrideObj.forLocales[locale]
+    ) {
       return formattedCurrency.replace(code, supportedCurrencySymbols[code]);
     } else {
       return formattedCurrency;
@@ -194,10 +209,14 @@ function initializeFormatters(isoCode, locale) {
   if (cachedFormatter == null) {
     formattersCache[cacheKey] = {};
     formattersCache[cacheKey].currencyFormatterNormal = currencyFormatterNormal;
-    formattersCache[cacheKey].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
+    formattersCache[
+      cacheKey
+    ].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
     formattersCache[cacheKey].currencyFormatterMedium = currencyFormatterMedium;
     formattersCache[cacheKey].currencyFormatterSmall = currencyFormatterSmall;
-    formattersCache[cacheKey].currencyFormatterVerySmall = currencyFormatterVerySmall;
+    formattersCache[
+      cacheKey
+    ].currencyFormatterVerySmall = currencyFormatterVerySmall;
   }
 }
 
@@ -228,19 +247,37 @@ export function formatCurrency(amount, isoCode, locale = "en", raw = false) {
     }
 
     if (amount === 0.0) {
-      return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNormal.format(amount),
+        locale
+      );
     } else if (price >= LARGE_CRYPTO_THRESHOLD) {
       // Large crypto amount, show no decimal value
-      return formatCurrencyOverride(currencyFormatterNoDecimal.format(amount), locale);
-    } else if (price >= MEDIUM_CRYPTO_THRESHOLD && price < LARGE_CRYPTO_THRESHOLD) {
+      return formatCurrencyOverride(
+        currencyFormatterNoDecimal.format(amount),
+        locale
+      );
+    } else if (
+      price >= MEDIUM_CRYPTO_THRESHOLD &&
+      price < LARGE_CRYPTO_THRESHOLD
+    ) {
       // Medium crypto amount, show 3 fraction digits
-      return formatCurrencyOverride(currencyFormatterMedium.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterMedium.format(amount),
+        locale
+      );
     } else if (price >= 1.0 && price < MEDIUM_CRYPTO_THRESHOLD) {
       //  crypto amount, show 6 fraction digits
-      return formatCurrencyOverride(currencyFormatterSmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterSmall.format(amount),
+        locale
+      );
     } else {
       // Crypto amount < 1, show 8 fraction digits
-      return formatCurrencyOverride(currencyFormatterVerySmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterVerySmall.format(amount),
+        locale
+      );
     }
   } else {
     if (raw) {
@@ -254,16 +291,31 @@ export function formatCurrency(amount, isoCode, locale = "en", raw = false) {
     }
 
     if (amount === 0.0) {
-      return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNormal.format(amount),
+        locale
+      );
     } else if (amount < 0.05) {
-      return formatCurrencyOverride(currencyFormatterVerySmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterVerySmall.format(amount),
+        locale
+      );
     } else if (amount < 1.0) {
-      return formatCurrencyOverride(currencyFormatterSmall.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterSmall.format(amount),
+        locale
+      );
     } else if (amount > 20000) {
-      return formatCurrencyOverride(currencyFormatterNoDecimal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNoDecimal.format(amount),
+        locale
+      );
     } else {
       // Let the formatter do what it seems best. In particular, we should not set any fraction amount for Japanese Yen
-      return formatCurrencyOverride(currencyFormatterNormal.format(amount), locale);
+      return formatCurrencyOverride(
+        currencyFormatterNormal.format(amount),
+        locale
+      );
     }
   }
 }

--- a/src/test.js
+++ b/src/test.js
@@ -11,26 +11,28 @@ describe("is crypto", () => {
   describe("raw = true", () => {
     test("returns precision of 8", () => {
       expect(formatCurrency(0.00001, "BTC", "en", true)).toBe("0.000010000000");
-      expect(formatCurrency(0.00001, "DOGE", "en", true)).toBe("0.000010000000");
+      expect(formatCurrency(0.00001, "DOGE", "en", true)).toBe(
+        "0.000010000000"
+      );
     });
   });
 
   describe("raw = false", () => {
     test("returns formatted", () => {
-      expect(formatCurrency(0.0, "BTC", "en")).toBe("Ƀ0.00");
+      expect(formatCurrency(0.0, "BTC", "en")).toBe("₿0.00");
 
       // Large cyrpto, no decimals
-      expect(formatCurrency(1001, "BTC", "en")).toBe("Ƀ1,001");
+      expect(formatCurrency(1001, "BTC", "en")).toBe("₿1,001");
 
       // Medium cyrpto, 3 decimals
-      expect(formatCurrency(51.1, "BTC", "en")).toBe("Ƀ51.100");
+      expect(formatCurrency(51.1, "BTC", "en")).toBe("₿51.100");
 
       // Small cyrpto, 6 decimals
-      expect(formatCurrency(11.1, "BTC", "en")).toBe("Ƀ11.100000");
+      expect(formatCurrency(11.1, "BTC", "en")).toBe("₿11.100000");
       expect(formatCurrency(9.234, "ETH", "en")).toBe("Ξ9.234000");
 
       // Very small cyrpto, 8 decimals
-      expect(formatCurrency(0.5, "BTC", "en")).toBe("Ƀ0.50000000");
+      expect(formatCurrency(0.5, "BTC", "en")).toBe("₿0.50000000");
 
       // Non-BTC or ETH
       expect(formatCurrency(1.1, "DOGE", "en")).toBe("1.100000 DOGE");
@@ -82,7 +84,9 @@ describe("Intl.NumberFormat not supported", () => {
   describe("is BTC or ETH", () => {
     describe("raw = true", () => {
       test("returns precision of 8", () => {
-        expect(formatCurrency(0.00001, "BTC", "en", true)).toBe("0.000010000000");
+        expect(formatCurrency(0.00001, "BTC", "en", true)).toBe(
+          "0.000010000000"
+        );
       });
     });
 


### PR DESCRIPTION
> The unicode character 20BF is the recently approved currency symbol for Bitcoin. Most modern programs support this if you do a little digging. Much cooler compared to typing BTC all the time. Looks like this: ₿


Old standard: https://bitcoinsymbol.org/
New Logo: https://en.wiktionary.org/wiki/%E2%82%BF