### PR TITLE
[Bug #18] Fix JPY currency for value < 100

### DIFF
--- a/lib/cryptoformat.cjs.js
+++ b/lib/cryptoformat.cjs.js
@@ -178,6 +178,7 @@ let currentLocale;
 let currencyFormatterNormal;
 let currencyFormatterNoDecimal;
 let currencyFormatterMedium;
+let currencyFormatterTwoDecimal;
 let currencyFormatterSmall;
 let currencyFormatterVerySmall;
 
@@ -202,6 +203,9 @@ function initializeFormatters(isoCode, locale) {
   currencyFormatterMedium = cachedFormatter
     ? cachedFormatter.currencyFormatterMedium
     : generateFormatter(isoCode, locale, 3);
+  currencyFormatterTwoDecimal = cachedFormatter
+    ? cachedFormatter.currencyFormatterTwoDecimal
+    : generateFormatter(isoCode, locale, 2);
   currencyFormatterSmall = cachedFormatter
     ? cachedFormatter.currencyFormatterSmall
     : generateFormatter(isoCode, locale, 6);
@@ -217,6 +221,9 @@ function initializeFormatters(isoCode, locale) {
       cacheKey
     ].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
     formattersCache[cacheKey].currencyFormatterMedium = currencyFormatterMedium;
+    formattersCache[
+      cacheKey
+    ].currencyFormatterTwoDecimal = currencyFormatterTwoDecimal;
     formattersCache[cacheKey].currencyFormatterSmall = currencyFormatterSmall;
     formattersCache[
       cacheKey
@@ -307,6 +314,11 @@ function formatCurrency(amount, isoCode, locale = "en", raw = false) {
     } else if (amount < 1.0) {
       return formatCurrencyOverride(
         currencyFormatterSmall.format(amount),
+        locale
+      );
+    } else if (isoCode === "JPY" && amount < 100) {
+      return formatCurrencyOverride(
+        currencyFormatterTwoDecimal.format(amount),
         locale
       );
     } else if (amount > 20000) {

--- a/lib/cryptoformat.esm.js
+++ b/lib/cryptoformat.esm.js
@@ -174,6 +174,7 @@ let currentLocale;
 let currencyFormatterNormal;
 let currencyFormatterNoDecimal;
 let currencyFormatterMedium;
+let currencyFormatterTwoDecimal;
 let currencyFormatterSmall;
 let currencyFormatterVerySmall;
 
@@ -198,6 +199,9 @@ function initializeFormatters(isoCode, locale) {
   currencyFormatterMedium = cachedFormatter
     ? cachedFormatter.currencyFormatterMedium
     : generateFormatter(isoCode, locale, 3);
+  currencyFormatterTwoDecimal = cachedFormatter
+    ? cachedFormatter.currencyFormatterTwoDecimal
+    : generateFormatter(isoCode, locale, 2);
   currencyFormatterSmall = cachedFormatter
     ? cachedFormatter.currencyFormatterSmall
     : generateFormatter(isoCode, locale, 6);
@@ -213,6 +217,9 @@ function initializeFormatters(isoCode, locale) {
       cacheKey
     ].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
     formattersCache[cacheKey].currencyFormatterMedium = currencyFormatterMedium;
+    formattersCache[
+      cacheKey
+    ].currencyFormatterTwoDecimal = currencyFormatterTwoDecimal;
     formattersCache[cacheKey].currencyFormatterSmall = currencyFormatterSmall;
     formattersCache[
       cacheKey
@@ -303,6 +310,11 @@ function formatCurrency(amount, isoCode, locale = "en", raw = false) {
     } else if (amount < 1.0) {
       return formatCurrencyOverride(
         currencyFormatterSmall.format(amount),
+        locale
+      );
+    } else if (isoCode === "JPY" && amount < 100) {
+      return formatCurrencyOverride(
+        currencyFormatterTwoDecimal.format(amount),
         locale
       );
     } else if (amount > 20000) {

--- a/lib/cryptoformat.umd.js
+++ b/lib/cryptoformat.umd.js
@@ -180,6 +180,7 @@
   let currencyFormatterNormal;
   let currencyFormatterNoDecimal;
   let currencyFormatterMedium;
+  let currencyFormatterTwoDecimal;
   let currencyFormatterSmall;
   let currencyFormatterVerySmall;
 
@@ -204,6 +205,9 @@
     currencyFormatterMedium = cachedFormatter
       ? cachedFormatter.currencyFormatterMedium
       : generateFormatter(isoCode, locale, 3);
+    currencyFormatterTwoDecimal = cachedFormatter
+      ? cachedFormatter.currencyFormatterTwoDecimal
+      : generateFormatter(isoCode, locale, 2);
     currencyFormatterSmall = cachedFormatter
       ? cachedFormatter.currencyFormatterSmall
       : generateFormatter(isoCode, locale, 6);
@@ -219,6 +223,9 @@
         cacheKey
       ].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
       formattersCache[cacheKey].currencyFormatterMedium = currencyFormatterMedium;
+      formattersCache[
+        cacheKey
+      ].currencyFormatterTwoDecimal = currencyFormatterTwoDecimal;
       formattersCache[cacheKey].currencyFormatterSmall = currencyFormatterSmall;
       formattersCache[
         cacheKey
@@ -309,6 +316,11 @@
       } else if (amount < 1.0) {
         return formatCurrencyOverride(
           currencyFormatterSmall.format(amount),
+          locale
+        );
+      } else if (isoCode === "JPY" && amount < 100) {
+        return formatCurrencyOverride(
+          currencyFormatterTwoDecimal.format(amount),
           locale
         );
       } else if (amount > 20000) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1686,9 +1686,9 @@
       }
     },
     "commander": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
-      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "optional": true
     },
@@ -3061,9 +3061,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
-      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.1.tgz",
+      "integrity": "sha512-2dd6soo60cwKNJ90VewNLIzdZPR/E2YhszOTgHpN9V0YuwZk7x33/iZoIBnASwDFVHMY7iJ6NPL8d9f/DWYCTA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5736,13 +5736,13 @@
       }
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.5.tgz",
+      "integrity": "sha512-GFZ3EXRptKGvb/C1Sq6nO1iI7AGcjyqmIyOw0DrD0675e+NNbGO72xmMM2iEBdFbxaTLo70NbjM/Wy54uZIlsg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coingecko/cryptoformat",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Javascript library to format and display cryptocurrencies and fiat",
   "main": "lib/cryptoformat.cjs.js",
   "module": "lib/cryptoformat.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -174,6 +174,7 @@ let currentLocale;
 let currencyFormatterNormal;
 let currencyFormatterNoDecimal;
 let currencyFormatterMedium;
+let currencyFormatterTwoDecimal;
 let currencyFormatterSmall;
 let currencyFormatterVerySmall;
 
@@ -198,6 +199,9 @@ function initializeFormatters(isoCode, locale) {
   currencyFormatterMedium = cachedFormatter
     ? cachedFormatter.currencyFormatterMedium
     : generateFormatter(isoCode, locale, 3);
+  currencyFormatterTwoDecimal = cachedFormatter
+    ? cachedFormatter.currencyFormatterTwoDecimal
+    : generateFormatter(isoCode, locale, 2);
   currencyFormatterSmall = cachedFormatter
     ? cachedFormatter.currencyFormatterSmall
     : generateFormatter(isoCode, locale, 6);
@@ -213,6 +217,9 @@ function initializeFormatters(isoCode, locale) {
       cacheKey
     ].currencyFormatterNoDecimal = currencyFormatterNoDecimal;
     formattersCache[cacheKey].currencyFormatterMedium = currencyFormatterMedium;
+    formattersCache[
+      cacheKey
+    ].currencyFormatterTwoDecimal = currencyFormatterTwoDecimal;
     formattersCache[cacheKey].currencyFormatterSmall = currencyFormatterSmall;
     formattersCache[
       cacheKey
@@ -303,6 +310,11 @@ export function formatCurrency(amount, isoCode, locale = "en", raw = false) {
     } else if (amount < 1.0) {
       return formatCurrencyOverride(
         currencyFormatterSmall.format(amount),
+        locale
+      );
+    } else if (isoCode === "JPY" && amount < 100) {
+      return formatCurrencyOverride(
+        currencyFormatterTwoDecimal.format(amount),
         locale
       );
     } else if (amount > 20000) {

--- a/src/test.js
+++ b/src/test.js
@@ -76,9 +76,15 @@ describe("is fiat", () => {
 });
 
 describe("Intl.NumberFormat not supported", () => {
+  let temp = Intl.NumberFormat;
+
   beforeAll(() => {
     Intl.NumberFormat = null;
     clearCache();
+  });
+
+  afterAll(() => {
+    Intl.NumberFormat = temp;
   });
 
   describe("is BTC or ETH", () => {
@@ -146,5 +152,17 @@ describe("Intl.NumberFormat not supported", () => {
         expect(formatCurrency(51100, "USD", "en")).toBe("USD 51,100");
       });
     });
+  });
+});
+
+describe("Format Currency correctly", () => {
+  beforeAll(() => {
+    clearCache();
+  });
+
+  // https://github.com/coingecko/cryptoformat/issues/18
+  it("formats JPY correctly", () => {
+    expect(formatCurrency(123400, "JPY", "en")).toEqual("¥123,400");
+    expect(formatCurrency(32.034, "JPY", "en")).toEqual("¥32.03");
   });
 });


### PR DESCRIPTION
Refer to issue https://github.com/coingecko/cryptoformat/issues/18

Created a new currencyFormatter: `currencyFormatterTwoDecimal` for this use case.

@wenjieyek do you think need to allow this behaviour for other fiat currency?