### PR TITLE
Rename noDecimalObject to decimalConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ formatCurrency(123400, "EUR", "de");
 formatCurrency(4000.23, "USD", "en", false, true);
 // "$4,000"
 
+// Provide number of decimal places or significant figures
+formatCurrency(1.234, "USD", "en", false, { decimalPlaces: 2 });
+// "$1.23"
+
+formatCurrency(1234, "USD", "en", false, { significantFigures: 2 });
+// "$1,200"
+
+// Provide number of significant figures only up to specified number of decimal places 
+formatCurrency(0.1234, "USD", "en", false, { decimalPlaces: 2, significantFigures: 3 });
+// "$0.12"
+
 ```
 
 `cryptoformat` tries to cache formatters for reuse internally. If same locale and currency is used, the cached formatter will be used.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,7 +25,7 @@ export function formatCurrency(
   noDecimal: boolean | decimalConfig
 ): string;
 
-interface decimalConfig{
+interface decimalConfig {
   decimalPlaces?: number, 
   significantFigures?: number 
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,10 +22,10 @@ export function formatCurrency(
   isoCode: string,
   locale: string,
   raw: boolean,
-  noDecimal: boolean | noDecimalObject
-): number;
+  noDecimal: boolean | decimalConfig
+): string;
 
-interface noDecimalObject{
-  dp?: number, // number of decimal places
-  sf?: number // number of significant figures
+interface decimalConfig{
+  decimalPlaces?: number, 
+  significantFigures?: number 
 }

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export function isCrypto(isoCode) {
   return isBTCETH(isoCode) || supportedCurrencySymbols[isoCode] == null;
 }
 
-// Function to transignificantFiguresorm the output from Intl.NumberFormat#format
+// Function to transform the output from Intl.NumberFormat#format
 function formatCurrencyOverride(formattedCurrency, locale = "en") {
   // If currency code remains in front
   const currencyCodeFrontMatch = formattedCurrency.match(/^[A-Z]{3}\s?/);

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export function isCrypto(isoCode) {
   return isBTCETH(isoCode) || supportedCurrencySymbols[isoCode] == null;
 }
 
-// Function to transform the output from Intl.NumberFormat#format
+// Function to transignificantFiguresorm the output from Intl.NumberFormat#format
 function formatCurrencyOverride(formattedCurrency, locale = "en") {
   // If currency code remains in front
   const currencyCodeFrontMatch = formattedCurrency.match(/^[A-Z]{3}\s?/);
@@ -260,26 +260,26 @@ export function formatCurrency(
   } else if (typeof noDecimal === "object" && noDecimal !== null) {
     if (raw) {
       // Limit to max n decimal places if applicable
-      let raw_amount = noDecimal.hasOwnProperty("dp")
-        ? amount.toFixed(noDecimal.dp)
+      let raw_amount = noDecimal.hasOwnProperty("decimalPlaces")
+        ? amount.toFixed(noDecimal.decimalPlaces)
         : amount;
       // Round off to number of significant figures without trailing 0's
-      return `${parseFloat(raw_amount).toPrecision(noDecimal.sf) / 1}`;
+      return `${parseFloat(raw_amount).toPrecision(noDecimal.significantFigures) / 1}`;
     } else if (
-      noDecimal.hasOwnProperty("dp") &&
-      noDecimal.hasOwnProperty("sf")
+      noDecimal.hasOwnProperty("decimalPlaces") &&
+      noDecimal.hasOwnProperty("significantFigures")
     ) {
       // Show specified number of significant digits with cutoff of specified fraction digits
       const currencyFormatterCustom = generateFormatter(
         isoCode,
         locale,
         undefined,
-        noDecimal.sf
+        noDecimal.significantFigures
       );
 
       return formatCurrencyOverride(
         currencyFormatterCustom.format(
-          Number.parseFloat(amount.toFixed(noDecimal.dp))
+          Number.parseFloat(amount.toFixed(noDecimal.decimalPlaces))
         ),
         locale
       );
@@ -287,8 +287,8 @@ export function formatCurrency(
       const currencyFormatterCustom = generateFormatter(
         isoCode,
         locale,
-        noDecimal.dp,
-        noDecimal.sf
+        noDecimal.decimalPlaces,
+        noDecimal.significantFigures
       );
 
       return formatCurrencyOverride(

--- a/src/test.js
+++ b/src/test.js
@@ -215,43 +215,43 @@ describe("Accepts object parameter", () => {
 
   it("formats decimal places correctly", () => {
     // Show specified number of decimal places
-    expect(formatCurrency(123.456, "USD", "en", false, {dp:1})).toEqual("$123.5");
-    expect(formatCurrency(1000.12345, "USD", "en", false, {dp: 3})).toEqual("$1,000.123");
-    expect(formatCurrency(0.19, "BTC", "en", false, {dp: 5})).toEqual("₿0.19000");
+    expect(formatCurrency(123.456, "USD", "en", false, {decimalPlaces:1})).toEqual("$123.5");
+    expect(formatCurrency(1000.12345, "USD", "en", false, {decimalPlaces: 3})).toEqual("$1,000.123");
+    expect(formatCurrency(0.19, "BTC", "en", false, {decimalPlaces: 5})).toEqual("₿0.19000");
   });
 
   it("formats significant figures correctly", () => {
     // Round off to max n significant figures
-    expect(formatCurrency(12311.456, "USD", "en", false, {sf: 1})).toEqual("$10,000");
-    expect(formatCurrency(0.99999, "USD", "en", false, {sf: 2})).toEqual("$1");
-    expect(formatCurrency(1000.12345, "USD", "en", false, {sf: 5})).toEqual("$1,000.1");
+    expect(formatCurrency(12311.456, "USD", "en", false, {significantFigures: 1})).toEqual("$10,000");
+    expect(formatCurrency(0.99999, "USD", "en", false, {significantFigures: 2})).toEqual("$1");
+    expect(formatCurrency(1000.12345, "USD", "en", false, {significantFigures: 5})).toEqual("$1,000.1");
   });
   
   it("formats decimal places and significant figures correctly", () => {
     // Round off to max n significant figures, with max 2 decimal places
-    expect(formatCurrency(123.456, "USD", "en", false, {dp: 2, sf: 3})).toEqual("$123");
-    expect(formatCurrency(12.345678, "USD", "en", false, {dp: 2, sf: 4})).toEqual("$12.35");
-    expect(formatCurrency(1005.15, "USD", "en", false, {dp: 2, sf: 5})).toEqual("$1,005.2");
+    expect(formatCurrency(123.456, "USD", "en", false, {decimalPlaces: 2, significantFigures: 3})).toEqual("$123");
+    expect(formatCurrency(12.345678, "USD", "en", false, {decimalPlaces: 2, significantFigures: 4})).toEqual("$12.35");
+    expect(formatCurrency(1005.15, "USD", "en", false, {decimalPlaces: 2, significantFigures: 5})).toEqual("$1,005.2");
     // Handle edge case, should only round once
-    expect(formatCurrency(1.94999, "USD", "en", false, {dp: 2, sf: 4})).toEqual("$1.95");
+    expect(formatCurrency(1.94999, "USD", "en", false, {decimalPlaces: 2, significantFigures: 4})).toEqual("$1.95");
 
     // Round off to max 6 significant figures, with max n decimal places
-    expect(formatCurrency(0.00016, "USD", "en", false, {dp: 4, sf: 6})).toEqual("$0.0002");
-    expect(formatCurrency(1234.56789, "USD", "en", false, {dp: 3, sf: 6})).toEqual("$1,234.57");
-    expect(formatCurrency(0.000000012345, "BTC", "en", false, {dp: 8, sf: 6})).toEqual("₿0.00000001");
+    expect(formatCurrency(0.00016, "USD", "en", false, {decimalPlaces: 4, significantFigures: 6})).toEqual("$0.0002");
+    expect(formatCurrency(1234.56789, "USD", "en", false, {decimalPlaces: 3, significantFigures: 6})).toEqual("$1,234.57");
+    expect(formatCurrency(0.000000012345, "BTC", "en", false, {decimalPlaces: 8, significantFigures: 6})).toEqual("₿0.00000001");
   });
 
   it("raw = true", () => {
     // Round off to specified significant figure only
-    expect(formatCurrency(123.456, "USD", "en", true, {sf: 5})).toEqual("123.46");
+    expect(formatCurrency(123.456, "USD", "en", true, {significantFigures: 5})).toEqual("123.46");
     
     // Show up to specified fraction digits only
-    expect(formatCurrency(123.456, "USD", "en", true, {dp: 0})).toEqual("123");
+    expect(formatCurrency(123.456, "USD", "en", true, {decimalPlaces: 0})).toEqual("123");
     
     // Round off to max n significant figures, with max n decimal places
-    expect(formatCurrency(123.456, "USD", "en", true, {dp: 8, sf: 5})).toEqual("123.46");
-    expect(formatCurrency(123456.78, "USD", "en", true, {dp: 1, sf: 10})).toEqual("123456.8");
+    expect(formatCurrency(123.456, "USD", "en", true, {decimalPlaces: 8, significantFigures: 5})).toEqual("123.46");
+    expect(formatCurrency(123456.78, "USD", "en", true, {decimalPlaces: 1, significantFigures: 10})).toEqual("123456.8");
     // Handle edge case, should only round once
-    expect(formatCurrency(1.94999, "USD", "en", true, {dp: 2, sf: 2})).toEqual("1.9");
+    expect(formatCurrency(1.94999, "USD", "en", true, {decimalPlaces: 2, significantFigures: 2})).toEqual("1.9");
   })  
 });


### PR DESCRIPTION
- Change `decimalConfig` property names to `decimalPlaces` and `significantFigures`
- Change formatCurrency return type to `string`