### PR TITLE
Add formatting to abbreviated numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coingecko/cryptoformat",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Javascript library to format and display cryptocurrencies and fiat",
   "main": "lib/cryptoformat.cjs.js",
   "module": "lib/cryptoformat.esm.js",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,6 +24,14 @@ export function formatCurrency(
   raw: boolean,
   noDecimal: boolean | decimalConfig
 ): string;
+export function formatCurrency(
+  amount: number,
+  isoCode: string,
+  locale: string,
+  raw: boolean,
+  noDecimal: boolean | decimalConfig,
+  abbreviated: boolean,
+): string;
 
 interface decimalConfig {
   decimalPlaces?: number, 

--- a/src/index.js
+++ b/src/index.js
@@ -273,7 +273,8 @@ export function formatCurrency(
   isoCode,
   locale = "en",
   raw = false,
-  noDecimal = false
+  noDecimal = false,
+  abbreviated = false,
 ) {
   isoCode = isoCode.toUpperCase();
 
@@ -283,6 +284,17 @@ export function formatCurrency(
 
     // Formatters are tied to currency code, we try to initialize as infrequently as possible.
     initializeFormatters(isoCode, locale);
+  }
+
+  if (abbreviated) {
+    let formattedAbbreviatedCurrency = currencyFormatterAbbreviated.format(amount);
+
+    // Manually add currency code to the back for non-BTC/ETH crypto currencies.
+    if (isCrypto(isoCode) && !isBTCETH(isoCode)) {
+      formattedAbbreviatedCurrency = `${formattedAbbreviatedCurrency} ${isoCode}`;
+    }
+
+    return formatCurrencyOverride(formattedAbbreviatedCurrency, locale);
   }
 
   if (noDecimal === true && amount > 100.0) {

--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,23 @@ function generateFallbackFormatter(isoCode, locale, numDecimals = 2) {
   }
 }
 
+function generateAbbreviatedFormatter(isoCode, locale) {
+  // Show regular numbers if no Intl.NumberFormat support.
+  if (!IntlNumberFormatSupported()) {
+    return generateFallbackFormatter(isoCode, locale, 0);
+  }
+
+  let numberFormatOptions = { style: "decimal", notation: "compact", minimumFractionDigits: 0, maximumFractionDigits: 2 };
+
+  // Currency symbol is supported if currency is Fiat/BTC/ETH.
+  if (!isCrypto(isoCode) || isBTCETH(isoCode)) {
+    numberFormatOptions.style = "currency";
+    numberFormatOptions.currency = isoCode;
+  }
+
+  return new Intl.NumberFormat(locale, numberFormatOptions);
+}
+
 function generateFormatter(isoCode, locale, numDecimals, numSigFig) {
   const isNumberFormatSupported = IntlNumberFormatSupported();
 
@@ -183,6 +200,7 @@ let currencyFormatterVerySmall;
 let currencyFormatterVeryVerySmall;
 let currencyFormatter15DP;
 let currencyFormatter18DP;
+let currencyFormatterAbbreviated;
 
 // If a page has to display multiple currencies, formatters would have to be created for each of them
 // To save some effort, we save formatters for reuse
@@ -223,6 +241,9 @@ function initializeFormatters(isoCode, locale) {
   currencyFormatter18DP = cachedFormatter
     ? cachedFormatter.currencyFormatter18DP
     : generateFormatter(isoCode, locale, 18);
+  currencyFormatterAbbreviated = cachedFormatter
+    ? cachedFormatter.currencyFormatterAbbreviated
+    : generateAbbreviatedFormatter(isoCode, locale);
 
   // Save in cache
   if (cachedFormatter == null) {
@@ -236,6 +257,7 @@ function initializeFormatters(isoCode, locale) {
     formattersCache[cacheKey].currencyFormatterVeryVerySmall = currencyFormatterVeryVerySmall;
     formattersCache[cacheKey].currencyFormatter15DP = currencyFormatter15DP;
     formattersCache[cacheKey].currencyFormatter18DP = currencyFormatter18DP;
+    formattersCache[cacheKey].currencyFormatterAbbreviated = currencyFormatterAbbreviated;
   }
 }
 

--- a/src/test.js
+++ b/src/test.js
@@ -62,6 +62,26 @@ describe("is crypto", () => {
       expect(formatCurrency(0.5, "BTC", "en", false, true)).toBe("₿0.50000000");
     })
   });
+
+  describe("abbreviated = true", () => {
+    test("returns abbreviated format (EN)", () => {
+      expect(formatCurrency(12311111, "BTC", "en", false, false, true)).toBe("₿12.31M");
+      expect(formatCurrency(1000000000, "BTC", "en", false, false, true)).toBe("₿1B");
+      expect(formatCurrency(10000000, "ETH", "en", false, false, true)).toBe("Ξ10M");
+      expect(formatCurrency(100000000, "ETH", "en", false, false, true)).toBe("Ξ100M");
+      expect(formatCurrency(10000000, "DOGE", "en", false, false, true)).toBe("10M DOGE");
+      expect(formatCurrency(100000000, "DOGE", "en", false, false, true)).toBe("100M DOGE");
+    });
+
+    test("returns abbreviated format (JA)", () => {
+      expect(formatCurrency(12311111, "BTC", "ja", false, false, true)).toBe("BTC 1231.11万");
+      expect(formatCurrency(1000000000, "BTC", "ja", false, false, true)).toBe("BTC 10億");
+      expect(formatCurrency(10000000, "ETH", "ja", false, false, true)).toBe("ETH 1000万");
+      expect(formatCurrency(100000000, "ETH", "ja", false, false, true)).toBe("ETH 1億");
+      expect(formatCurrency(10000000, "DOGE", "ja", false, false, true)).toBe("1000万 DOGE");
+      expect(formatCurrency(100000000, "DOGE", "ja", false, false, true)).toBe("1億 DOGE");
+    });
+  });
 });
 
 describe("is fiat", () => {
@@ -142,6 +162,26 @@ describe("is fiat", () => {
       expect(formatCurrency(0.5, "USD", "en", false, true)).toBe("$0.500000");
       expect(formatCurrency(0.00002, "USD", "en", false, true)).toBe("$0.00002000");
     })
+  });
+
+  describe("abbreviated = true", () => {
+    test("returns abbreviated format (EN)", () => {
+      expect(formatCurrency(10200000, "USD", "en", false, false, true)).toBe("$10.2M");
+      expect(formatCurrency(12100000000, "USD", "en", false, false, true)).toBe("$12.1B");
+      expect(formatCurrency(10000000, "AUD", "en", false, false, true)).toBe("A$10M");
+      expect(formatCurrency(100000000, "AUD", "en", false, false, true)).toBe("A$100M");
+      expect(formatCurrency(10000000, "JPY", "en", false, false, true)).toBe("¥10M");
+      expect(formatCurrency(100000000, "JPY", "en", false, false, true)).toBe("¥100M");
+    });
+
+    test("returns abbreviated format (JA)", () => {
+      expect(formatCurrency(12000000, "USD", "ja", false, false, true)).toBe("$1200万");
+      expect(formatCurrency(1210000000, "USD", "ja", false, false, true)).toBe("$12.1億");
+      expect(formatCurrency(10000000, "AUD", "ja", false, false, true)).toBe("A$1000万");
+      expect(formatCurrency(100000000, "AUD", "ja", false, false, true)).toBe("A$1億");
+      expect(formatCurrency(10000000, "JPY", "ja", false, false, true)).toBe("￥1000万");
+      expect(formatCurrency(100000000, "JPY", "ja", false, false, true)).toBe("￥1億");
+    });
   });
 });
 


### PR DESCRIPTION
Adds formatting to abbreviated numbers.

e.g. `$1000000000` will be displayed as `$1B`, and `$1000000` will be displayed as `$1M`.

Uses `Intl.NumberFormat` internally, so the abbreviated `M`, `B`, and `T` forms are automatically localized, and have their number units automatically corrected. (e.g. Chinese, Japanese have a "wan"/"man" character that means "ten thousand")