### PR TITLE
Increase abbreviated format to 3 decimal points

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coingecko/cryptoformat",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Javascript library to format and display cryptocurrencies and fiat",
   "main": "lib/cryptoformat.cjs.js",
   "module": "lib/cryptoformat.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ function generateAbbreviatedFormatter(isoCode, locale) {
     return generateFallbackFormatter(isoCode, locale, 0);
   }
 
-  let numberFormatOptions = { style: "decimal", notation: "compact", minimumFractionDigits: 0, maximumFractionDigits: 2 };
+  let numberFormatOptions = { style: "decimal", notation: "compact", minimumFractionDigits: 0, maximumFractionDigits: 3 };
 
   // Currency symbol is supported if currency is Fiat/BTC/ETH.
   if (!isCrypto(isoCode) || isBTCETH(isoCode)) {

--- a/src/test.js
+++ b/src/test.js
@@ -65,7 +65,7 @@ describe("is crypto", () => {
 
   describe("abbreviated = true", () => {
     test("returns abbreviated format (EN)", () => {
-      expect(formatCurrency(12311111, "BTC", "en", false, false, true)).toBe("₿12.31M");
+      expect(formatCurrency(12311111, "BTC", "en", false, false, true)).toBe("₿12.311M");
       expect(formatCurrency(1000000000, "BTC", "en", false, false, true)).toBe("₿1B");
       expect(formatCurrency(10000000, "ETH", "en", false, false, true)).toBe("Ξ10M");
       expect(formatCurrency(100000000, "ETH", "en", false, false, true)).toBe("Ξ100M");
@@ -74,7 +74,7 @@ describe("is crypto", () => {
     });
 
     test("returns abbreviated format (JA)", () => {
-      expect(formatCurrency(12311111, "BTC", "ja", false, false, true)).toBe("BTC 1231.11万");
+      expect(formatCurrency(12311111, "BTC", "ja", false, false, true)).toBe("BTC 1231.111万");
       expect(formatCurrency(1000000000, "BTC", "ja", false, false, true)).toBe("BTC 10億");
       expect(formatCurrency(10000000, "ETH", "ja", false, false, true)).toBe("ETH 1000万");
       expect(formatCurrency(100000000, "ETH", "ja", false, false, true)).toBe("ETH 1億");


### PR DESCRIPTION
From user feedbacks:-

<img width="1060" alt="image" src="https://github.com/coingecko/cryptoformat/assets/88306776/33c0c1db-d60c-457e-831c-0cd6ef2e5432">
<img width="1007" alt="image" src="https://github.com/coingecko/cryptoformat/assets/88306776/df850925-c689-4f84-8e57-8ff2cdbdb037">
