### PR TITLE
Add Support for Transforming Decimal Trailing Zeroes to Exponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coingecko/cryptoformat",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Javascript library to format and display cryptocurrencies and fiat",
   "main": "lib/cryptoformat.cjs.js",
   "module": "lib/cryptoformat.esm.js",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,6 +34,7 @@ export function formatCurrency(
 ): string;
 
 interface decimalConfig {
-  decimalPlaces?: number, 
-  significantFigures?: number 
+  decimalPlaces?: number,
+  significantFigures?: number,
+  maximumDecimalTrailingZeroes?: number
 }

--- a/src/test.js
+++ b/src/test.js
@@ -327,18 +327,30 @@ describe("Accepts object parameter", () => {
     expect(formatCurrency(1000.12345, "USD", "en", false, {significantFigures: 5})).toEqual("$1,000.1");
   });
 
-  it("formats decimal places and significant figures correctly", () => {
-    // Round off to max n significant figures, with max 2 decimal places
-    expect(formatCurrency(123.456, "USD", "en", false, {decimalPlaces: 2, significantFigures: 3})).toEqual("$123");
-    expect(formatCurrency(12.345678, "USD", "en", false, {decimalPlaces: 2, significantFigures: 4})).toEqual("$12.35");
-    expect(formatCurrency(1005.15, "USD", "en", false, {decimalPlaces: 2, significantFigures: 5})).toEqual("$1,005.2");
-    // Handle edge case, should only round once
-    expect(formatCurrency(1.94999, "USD", "en", false, {decimalPlaces: 2, significantFigures: 4})).toEqual("$1.95");
+  it("formats decimal trailing zeroes correctly", () => {
+    // Round off to max n significant figures
+    expect(formatCurrency(0.00, "USD", "en", false, {maximumDecimalTrailingZeroes: 1})).toEqual("$0.0<sub title=\"$0.00\">2</sub>");
+    expect(formatCurrency(0.000023948, "USD", "en", false, {maximumDecimalTrailingZeroes: 4})).toEqual("$0.00002395");
+    expect(formatCurrency(0.00000000000000003928, "USD", "en", false, {maximumDecimalTrailingZeroes: 3})).toEqual("$0.0<sub title=\"$0.000000000000000039\">16</sub>39");
+  });
 
-    // Round off to max 6 significant figures, with max n decimal places
-    expect(formatCurrency(0.00016, "USD", "en", false, {decimalPlaces: 4, significantFigures: 6})).toEqual("$0.0002");
-    expect(formatCurrency(1234.56789, "USD", "en", false, {decimalPlaces: 3, significantFigures: 6})).toEqual("$1,234.57");
-    expect(formatCurrency(0.000000012345, "BTC", "en", false, {decimalPlaces: 8, significantFigures: 6})).toEqual("₿0.00000001");
+  it("formats decimal places, significant figures and decimal trailing zeroes correctly", () => {
+    // Round off to max n significant figures, with max n decimal places, and maximum 3 decimal trailing zeroes
+    expect(formatCurrency(123.456, "USD", "en", false, {decimalPlaces: 2, significantFigures: 3, maximumDecimalTrailingZeroes: 3})).toEqual("$123");
+    expect(formatCurrency(0.00043, "USD", "en", false, {decimalPlaces: 4, significantFigures: 5, maximumDecimalTrailingZeroes: 3})).toEqual("$0.0004");
+    expect(formatCurrency(1.000049500005, "USD", "en", false, {decimalPlaces: 7, significantFigures: 8, maximumDecimalTrailingZeroes: 3})).toEqual("$1.0<sub title=\"$1.0000495\">4</sub>495");
+    // Handle edge case, should only round once
+    expect(formatCurrency(1.94999, "USD", "en", false, {decimalPlaces: 2, significantFigures: 4, maximumDecimalTrailingZeroes: 2})).toEqual("$1.95");
+
+    // Round off to max n significant figures, with max 4 decimal places, and maximum n decimal trailing zeroes
+    expect(formatCurrency(0.003422, "USD", "en", false, {decimalPlaces: 4, significantFigures: 3, maximumDecimalTrailingZeroes: 1})).toEqual("$0.0<sub title=\"$0.0034\">2</sub>34");
+    expect(formatCurrency(34.0430, "USD", "en", false, {decimalPlaces: 4, significantFigures: 4, maximumDecimalTrailingZeroes: 3})).toEqual("$34.04");
+    expect(formatCurrency(0.000495343, "USD", "en", false, {decimalPlaces: 4, significantFigures: 5, maximumDecimalTrailingZeroes: 2})).toEqual("$0.0<sub title=\"$0.0005\">3</sub>5");
+
+    // Round off to max 6 significant figures, with max n decimal places, and maximum n decimal trailing zeroes
+    expect(formatCurrency(0.00394756, "USD", "en", false, {decimalPlaces: 2, significantFigures: 6, maximumDecimalTrailingZeroes: 2})).toEqual("$0");
+    expect(formatCurrency(12.0430324, "USD", "en", false, {decimalPlaces: 4, significantFigures: 6, maximumDecimalTrailingZeroes: 3})).toEqual("$12.043");
+    expect(formatCurrency(0.000495343, "USD", "en", false, {decimalPlaces: 5, significantFigures: 6, maximumDecimalTrailingZeroes: 1})).toEqual("$0.0<sub title=\"$0.0005\">3</sub>5");
   });
 
   it("raw = true", () => {


### PR DESCRIPTION
Actual frontend testing in local

<img width="1102" alt="image" src="https://github.com/coingecko/cryptoformat/assets/62604618/f77bb0e2-6fc2-4d31-b4f3-95494be127bc"><br>

Added updated test cases and passed all tests.
```
yarn run v1.22.19
$ jest
 PASS  src/test.js
  ✓ isCrypto (3ms)
  is crypto
    raw = true
      ✓ returns precision of 8 (13ms)
    raw = false
      ✓ returns formatted (3ms)
    noDecimal = true
      ✓ returns without decimal (1ms)
      ✓ returns decimal when less than 1 (1ms)
    abbreviated = true
      ✓ returns abbreviated format (EN) (1ms)
      ✓ returns abbreviated format (JA) (1ms)
  is fiat
    raw = true
      ✓ returns formatted raw (1ms)
    raw = false
      ✓ returns formatted with symbol (1ms)
    no decimal threshold
      ✓ returns decimal for amounts <= 100,000
      ✓ returns no decimal for amounts > 100,000 (1ms)
    noDecimal = true
      ✓ returns without decimal
      ✓ returns decimal when less than 1
    abbreviated = true
      ✓ returns abbreviated format (EN) (2ms)
      ✓ returns abbreviated format (JA) (1ms)
  Intl.NumberFormat not supported
    is BTC or ETH
      raw = true
        ✓ returns precision of 8
      raw = false
        ✓ returns currency with ISO Code (1ms)
    is fiat
      raw = true
        ✓ returns formatted raw (1ms)
      raw = false
        ✓ returns formatted with symbol (1ms)
  Format Currency correctly
    ✓ formats JPY correctly (1ms)
  Accepts object parameter
    ✓ defaults to noDecimal = false
    ✓ formats decimal places correctly (1ms)
    ✓ formats significant figures correctly (1ms)
    ✓ formats trailing decimal zeroes correctly (2ms)
    ✓ formats decimal places, significant figures and trailing decimal zeroes correctly (2ms)
    ✓ raw = true

Test Suites: 1 passed, 1 total
Tests:       26 passed, 26 total
Snapshots:   0 total
Time:        1.635s, estimated 2s
Ran all test suites.
✨  Done in 3.71s.
```