### PR TITLE
[Bug Fix] Fix Cases where Locales Present Decimal Separator as Comma 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coingecko/cryptoformat",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Javascript library to format and display cryptocurrencies and fiat",
   "main": "lib/cryptoformat.cjs.js",
   "module": "lib/cryptoformat.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -74,11 +74,11 @@ export function isCrypto(isoCode) {
 
 // Function to transform decimal trailing zeroes to exponent
 function decimalTrailingZeroesToExponent(formattedCurrency, maximumDecimalTrailingZeroes) {
-  const decimalTrailingZeroesPattern = new RegExp(`\\.(0{${maximumDecimalTrailingZeroes + 1},})(?=[1-9]?)`);
+  const decimalTrailingZeroesPattern = new RegExp(`(\\.|,)(0{${maximumDecimalTrailingZeroes + 1},})(?=[1-9]?)`);
 
   return formattedCurrency.replace(
       decimalTrailingZeroesPattern,
-      (match, decimalTrailingZeroes) => `.0<sub title=\"${formattedCurrency}\">${decimalTrailingZeroes.length}</sub>`,
+      (_match, separator, decimalTrailingZeroes) => `${separator}0<sub title=\"${formattedCurrency}\">${decimalTrailingZeroes.length}</sub>`,
   )
 }
 

--- a/src/test.js
+++ b/src/test.js
@@ -332,6 +332,8 @@ describe("Accepts object parameter", () => {
     expect(formatCurrency(0.00, "USD", "en", false, {maximumDecimalTrailingZeroes: 1})).toEqual("$0.0<sub title=\"$0.00\">2</sub>");
     expect(formatCurrency(0.000023948, "USD", "en", false, {maximumDecimalTrailingZeroes: 4})).toEqual("$0.00002395");
     expect(formatCurrency(0.00000000000000003928, "USD", "en", false, {maximumDecimalTrailingZeroes: 3})).toEqual("$0.0<sub title=\"$0.000000000000000039\">16</sub>39");
+    // \xa0 is non-breaking space
+    expect(formatCurrency(0.000000000008, "USD", "vi", false, {maximumDecimalTrailingZeroes: 3})).toEqual("0,0<sub title=\"0,000000000008000\xa0US$\">11</sub>8000\xa0US$");
   });
 
   it("formats decimal places, significant figures and decimal trailing zeroes correctly", () => {


### PR DESCRIPTION
Actual frontend testing.

<img width="984" alt="image" src="https://github.com/coingecko/cryptoformat/assets/62604618/ac795f13-a07b-4e43-9bb6-f3b52bdfb6d8">


Added updated test cases and passed all tests.

```
yarn test
yarn run v1.22.19
$ jest
 PASS  src/test.js
  ✓ isCrypto (3ms)
  is crypto
    raw = true
      ✓ returns precision of 8 (16ms)
    raw = false
      ✓ returns formatted (3ms)
    noDecimal = true
      ✓ returns without decimal
      ✓ returns decimal when less than 1 (1ms)
    abbreviated = true
      ✓ returns abbreviated format (EN) (1ms)
      ✓ returns abbreviated format (JA) (2ms)
  is fiat
    raw = true
      ✓ returns formatted raw (1ms)
    raw = false
      ✓ returns formatted with symbol (1ms)
    no decimal threshold
      ✓ returns decimal for amounts <= 100,000 (1ms)
      ✓ returns no decimal for amounts > 100,000
    noDecimal = true
      ✓ returns without decimal
      ✓ returns decimal when less than 1 (1ms)
    abbreviated = true
      ✓ returns abbreviated format (EN) (1ms)
      ✓ returns abbreviated format (JA) (2ms)
  Intl.NumberFormat not supported
    is BTC or ETH
      raw = true
        ✓ returns precision of 8
      raw = false
        ✓ returns currency with ISO Code (1ms)
    is fiat
      raw = true
        ✓ returns formatted raw (1ms)
      raw = false
        ✓ returns formatted with symbol (1ms)
  Format Currency correctly
    ✓ formats JPY correctly (1ms)
  Accepts object parameter
    ✓ defaults to noDecimal = false (1ms)
    ✓ formats decimal places correctly (3ms)
    ✓ formats significant figures correctly (1ms)
    ✓ formats decimal trailing zeroes correctly (1ms)
    ✓ formats decimal places, significant figures and decimal trailing zeroes correctly (2ms)
    ✓ raw = true (1ms)

Test Suites: 1 passed, 1 total
Tests:       26 passed, 26 total
Snapshots:   0 total
Time:        1.15s
Ran all test suites.
✨  Done in 1.89s.
```
