### PR TITLE
Support significant numbers for non-BTC/ETH crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@coingecko/cryptoformat",
-  "version": "0.5.4",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coingecko/cryptoformat",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Javascript library to format and display cryptocurrencies and fiat",
   "main": "lib/cryptoformat.cjs.js",
   "module": "lib/cryptoformat.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -148,12 +148,12 @@ function generateIntlNumberFormatter(isoCode, locale, numDecimals, numSigFig) {
   } catch (e) {
     // Unsupported currency, etc.
     // Use primitive fallback
-    return generateFallbackFormatter(isoCode, locale, numDecimals);
+    return generateFallbackFormatter(isoCode, locale, numDecimals, numSigFig);
   }
 }
 
 // Generates a primitive fallback formatter with no symbol support.
-function generateFallbackFormatter(isoCode, locale, numDecimals = 2) {
+function generateFallbackFormatter(isoCode, locale, numDecimals = 2, maximumSignificantDigits = 4) {
   isoCode = isoCode.toUpperCase();
 
   if (numDecimals > 2) {
@@ -167,9 +167,15 @@ function generateFallbackFormatter(isoCode, locale, numDecimals = 2) {
   } else {
     return {
       format: (value) => {
+        let formattedValue = value
+        // try using Intl.NumberFormat when possible to support max significant digits 
+        try {
+          formattedValue = new Intl.NumberFormat('en', { maximumSignificantDigits }).format(value)          
+        } catch (e) {}        
+
         return isCrypto(isoCode)
-          ? `${value.toLocaleString(locale)} ${isoCode}`
-          : `${isoCode} ${value.toLocaleString(locale)}`;
+          ? `${formattedValue.toLocaleString(locale)} ${isoCode}`
+          : `${isoCode} ${formattedValue.toLocaleString(locale)}`;
       },
     };
   }
@@ -199,7 +205,7 @@ function generateFormatter(isoCode, locale, numDecimals, numSigFig) {
     isNumberFormatSupported && (!isCrypto(isoCode) || isBTCETH(isoCode));
   return useIntlNumberFormatter
     ? generateIntlNumberFormatter(isoCode, locale, numDecimals, numSigFig)
-    : generateFallbackFormatter(isoCode, locale, numDecimals);
+    : generateFallbackFormatter(isoCode, locale, numDecimals, numSigFig);
 }
 
 // State variables

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,7 @@ function generateFallbackFormatter(isoCode, locale, numDecimals = 2, maximumSign
         let formattedValue = value
         // try using Intl.NumberFormat when possible to support max significant digits 
         try {
-          formattedValue = new Intl.NumberFormat('en', { maximumSignificantDigits }).format(value)          
+          formattedValue = new Intl.NumberFormat(locale, { maximumSignificantDigits }).format(value)          
         } catch (e) {}        
 
         return isCrypto(isoCode)

--- a/src/test.js
+++ b/src/test.js
@@ -353,6 +353,14 @@ describe("Accepts object parameter", () => {
     expect(formatCurrency(0.00394756, "USD", "en", false, {decimalPlaces: 2, significantFigures: 6, maximumDecimalTrailingZeroes: 2})).toEqual("$0");
     expect(formatCurrency(12.0430324, "USD", "en", false, {decimalPlaces: 4, significantFigures: 6, maximumDecimalTrailingZeroes: 3})).toEqual("$12.043");
     expect(formatCurrency(0.000495343, "USD", "en", false, {decimalPlaces: 5, significantFigures: 6, maximumDecimalTrailingZeroes: 1})).toEqual("$0.0<sub title=\"$0.0005\">3</sub>5");
+
+    // supported crypto exponents - with significant figures
+    expect(formatCurrency(0.00199843, "btc", "en", false, {significantFigures: 4, maximumDecimalTrailingZeroes: 1})).toEqual("₿0.0<sub title=\"BTC 0.001998\">2</sub>1998");
+    expect(formatCurrency(0.00199843, "btc", "en", false, {significantFigures: 6, maximumDecimalTrailingZeroes: 1})).toEqual("₿0.0<sub title=\"BTC 0.00199843\">2</sub>199843");
+
+    // non-supported crypto exponents - with significant figures
+    expect(formatCurrency(0.00199843, "bnb", "en", false, {significantFigures: 4, maximumDecimalTrailingZeroes: 1})).toEqual("0.0<sub title=\"0.001998 BNB\">2</sub>1998 BNB");
+    expect(formatCurrency(0.00199843, "bnb", "en", false, {significantFigures: 6, maximumDecimalTrailingZeroes: 1})).toEqual("0.0<sub title=\"0.00199843 BNB\">2</sub>199843 BNB");
   });
 
   it("raw = true", () => {

--- a/src/test.js
+++ b/src/test.js
@@ -361,6 +361,8 @@ describe("Accepts object parameter", () => {
     // non-supported crypto exponents - with significant figures
     expect(formatCurrency(0.00199843, "bnb", "en", false, {significantFigures: 4, maximumDecimalTrailingZeroes: 1})).toEqual("0.0<sub title=\"0.001998 BNB\">2</sub>1998 BNB");
     expect(formatCurrency(0.00199843, "bnb", "en", false, {significantFigures: 6, maximumDecimalTrailingZeroes: 1})).toEqual("0.0<sub title=\"0.00199843 BNB\">2</sub>199843 BNB");
+    expect(formatCurrency(0.00199000, "bnb", "en", false, {significantFigures: 6, maximumDecimalTrailingZeroes: 1})).toEqual("0.0<sub title=\"0.00199 BNB\">2</sub>199 BNB");
+    expect(formatCurrency(0.00199843, "bnb", "en", false, {significantFigures: 2, maximumDecimalTrailingZeroes: 1})).toEqual("0.0<sub title=\"0.002 BNB\">2</sub>2 BNB");
   });
 
   it("raw = true", () => {


### PR DESCRIPTION
BC: https://3.basecamp.com/4235100/buckets/12442138/todos/7592663274

Issue: 
![image](https://github.com/user-attachments/assets/e964672a-cebf-4ba8-8313-d440e4f02203)

The y-axis price is not helpful when reading the charts (without scrubbing) as the significant numbers are too limited (1 digit significant number).  This is for BUSD/BNB

![Screenshot 2024-07-15 at 10 53 00 AM](https://github.com/user-attachments/assets/aa234348-83e6-4cdc-9320-c0fe016acd3d)

However, it is showing up to 3 significant digits for BUSD/BTC. Therefore this chart is helpful


Solution:

Support significant figures param for non-BTC/ETH crypto

Tests:

New unit tests has been added to handle this new behaviour
