### PR TITLE
fix(deps): bump transitive js-yaml from 3.14.2 to 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5371,9 +5371,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+			"integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## What

Bumps the transitive `js-yaml` dev dependency from 3.14.2 to 3.15.1.

## Why

Three Dependabot alerts (#82, #83, #88) all point at quadratic-complexity denial of service issues in the 3.x line, and 3.15.1 is the first release that clears all of them:

| Advisory | Issue | Patched in |
| --- | --- | --- |
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | CPU consumption in `!!omap` resolution (the CVE-2026-59870 fix, never backported below 3.15.1) | 3.15.1 |
| [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) | YAML merge-key chains forcing quadratic CPU | 3.15.0 |
| [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) | Quadratic-complexity DoS in merge key handling via repeated aliases | 3.15.0 |

`npm audit` no longer reports `js-yaml` after this change.

## Scope

`js-yaml` comes in transitively through `@babel/core` at `^3.13.1`, which 3.15.1 satisfies, so `package.json` is untouched — this is a lockfile-only change. Nothing that ships in `lib/` is affected.

## Verification

- `npm ci`
- `npm test` — 72 passing
- `npm run build` — rollup build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)